### PR TITLE
FIX: Imports for User-Defined Conditions

### DIFF
--- a/calista/table.py
+++ b/calista/table.py
@@ -28,7 +28,11 @@ from calista.core.engine import DataFrameType, GenericColumnType, LazyEngine
 from calista.core.metrics import Metrics
 from calista.core.types_alias import ColumnName, PythonType, RuleName
 from calista.core.utils import import_engine
-from calista.engines.sql import SqlDataManager
+
+try:
+    from calista.engines.sql import SqlDataManager
+except ModuleNotFoundError:
+    SqlDataManager = None
 
 if TYPE_CHECKING:
     from calista.group import GroupedTable
@@ -103,8 +107,9 @@ class CalistaTable:
 
         expr = self._evaluate_condition(condition)
         dataset_filtered = self._engine.filter(expr)
-        if isinstance(dataset_filtered, SqlDataManager):
-            dataset_filtered = dataset_filtered.select_object
+        if SqlDataManager is not None:
+            if isinstance(dataset_filtered, SqlDataManager):
+                dataset_filtered = dataset_filtered.select_object
 
         new_engine = self._engine.create_new_instance_from_dataset(dataset_filtered)
 

--- a/calista/user_defined_condition.py
+++ b/calista/user_defined_condition.py
@@ -5,8 +5,6 @@ from pydantic import create_model
 
 from calista.core._conditions import Condition
 from calista.core.engine import LazyEngine, _camel_to_snake
-from calista.engines.bigquery import BigqueryEngine
-from calista.engines.pandas_ import Pandas_Engine
 
 __all__ = [
     "register_spark_condition",
@@ -55,7 +53,7 @@ class UserDefinedCondition:
 
     def __get__(self, instance: LazyEngine, owner: Type[LazyEngine]):
         def user_defined_condition(cond: Condition):
-            if owner in [Pandas_Engine, BigqueryEngine]:
+            if owner.__name__ in ["Pandas_Engine", "BigqueryEngine"]:
                 return self.func(
                     instance.dataset, **cond.model_dump(exclude={"is_aggregate"})
                 )

--- a/calista/user_defined_condition.py
+++ b/calista/user_defined_condition.py
@@ -1,12 +1,7 @@
 import inspect
 from typing import Any, Callable, Type, Union
 
-import pandas as pd
-import polars as pl
 from pydantic import create_model
-from pyspark.sql import DataFrame
-from snowflake.snowpark import DataFrame as SnowparkDataFrame
-from sqlalchemy.sql.selectable import Select
 
 from calista.core._conditions import Condition
 from calista.core.engine import LazyEngine, _camel_to_snake
@@ -21,15 +16,23 @@ __all__ = [
     "register_bigquery_condition",
 ]
 
-_DataFrameType = Union[DataFrame, SnowparkDataFrame, pd.DataFrame, pl.LazyFrame, Select]
+_DataFrameType = Union[
+    "pyspark.sql.DataFrame",
+    "snowflake.snowpark.DataFrame",
+    "pandas.DataFrame",
+    "polars.LazyFrame",
+    "sqlalchemy.sql.selectable.Select",
+]
 
 
-def _udc_to_condition_model(user_func: Callable) -> Type[Condition]:
+def _udc_to_condition_model(
+    user_func: Callable, dataframe_type: _DataFrameType
+) -> Type[Condition]:
     """Transform a user function into a Condition model"""
     model_params = dict()
     params = inspect.signature(user_func).parameters
     for p in params.values():
-        if issubclass(p.annotation, _DataFrameType):
+        if issubclass(p.annotation, dataframe_type):
             continue
 
         if p.kind in {p.KEYWORD_ONLY, p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD}:
@@ -62,7 +65,9 @@ class UserDefinedCondition:
         return user_defined_condition
 
 
-def _register_function_as_condition(name: str, engine: Type[LazyEngine]):
+def _register_function_as_condition(
+    name: str, engine: Type[LazyEngine], dataframe_type: _DataFrameType
+):
     if hasattr(engine, name):
         msg = f"{name} condition already exist in Calista"
         raise AttributeError(msg)
@@ -77,7 +82,7 @@ def _register_function_as_condition(name: str, engine: Type[LazyEngine]):
                 raise AttributeError(
                     "You must call your user defined condition providing keyword argument"
                 )
-            return _udc_to_condition_model(user_func)(**kwargs)
+            return _udc_to_condition_model(user_func, dataframe_type)(**kwargs)
 
         return condition
 
@@ -85,30 +90,50 @@ def _register_function_as_condition(name: str, engine: Type[LazyEngine]):
 
 
 def register_spark_condition(name: str) -> Callable:
+    from pyspark.sql import DataFrame
+
     from calista.engines.spark import SparkEngine
 
-    return _register_function_as_condition(name, SparkEngine)
+    DataFrameType = DataFrame
+
+    return _register_function_as_condition(name, SparkEngine, DataFrameType)
 
 
 def register_snowflake_condition(name: str) -> Callable:
+    from snowflake.snowpark import DataFrame as SnowparkDataFrame
+
     from calista.engines.snowflake import SnowflakeEngine
 
-    return _register_function_as_condition(name, SnowflakeEngine)
+    DataFrameType = SnowparkDataFrame
+
+    return _register_function_as_condition(name, SnowflakeEngine, DataFrameType)
 
 
 def register_polars_condition(name: str) -> Callable:
+    import polars as pl
+
     from calista.engines.polars_ import Polars_Engine
 
-    return _register_function_as_condition(name, Polars_Engine)
+    DataFrameType = pl.LazyFrame
+
+    return _register_function_as_condition(name, Polars_Engine, DataFrameType)
 
 
 def register_pandas_condition(name: str) -> Callable:
+    import pandas as pd
+
     from calista.engines.pandas_ import Pandas_Engine
 
-    return _register_function_as_condition(name, Pandas_Engine)
+    DataFrameType = pd.DataFrame
+
+    return _register_function_as_condition(name, Pandas_Engine, DataFrameType)
 
 
 def register_bigquery_condition(name: str) -> Callable:
+    from sqlalchemy.sql.selectable import Select
+
     from calista.engines.bigquery import BigqueryEngine
 
-    return _register_function_as_condition(name, BigqueryEngine)
+    DataFrameType = Select
+
+    return _register_function_as_condition(name, BigqueryEngine, DataFrameType)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ find = { namespaces = false }
 
 [project]
 name = "calista"
-version = "0.3.0"
+version = "0.3.1"
 authors = []
 description = "Comprehensive Python package designed to simplify data quality checks across multiple platforms"
 readme = "README.md"


### PR DESCRIPTION
- Fixed imports for User-Defined Conditions so that the user doesn't need all the options (Spark, Snowflake, BigQuery) to register a UDC.
- Fixed imports in table.py so that the user doesn't necessarily need to install BigQuery in Calista when working with other engines