### PR TITLE
FIX: UDC column name parameter

### DIFF
--- a/calista/core/_conditions.py
+++ b/calista/core/_conditions.py
@@ -29,6 +29,7 @@ class Condition(BaseModel):
     """
 
     is_aggregate: bool = False
+    is_udc: bool = False
 
     def __and__(self, other):
         """

--- a/calista/table.py
+++ b/calista/table.py
@@ -141,10 +141,11 @@ class CalistaTable:
                 )
             return self._engine[condition](condition)
 
-        if condition.col_name not in self.schema.keys():
-            raise Exception(
-                f"Column '{condition.col_name}' not found in {list(self.schema.keys())}"
-            )
+        if not (condition.is_udc):
+            if condition.col_name not in self.schema.keys():
+                raise Exception(
+                    f"Column '{condition.col_name}' not found in {list(self.schema.keys())}"
+                )
 
         return self._engine[condition](condition)
 

--- a/calista/user_defined_condition.py
+++ b/calista/user_defined_condition.py
@@ -28,6 +28,7 @@ def _udc_to_condition_model(
 ) -> Type[Condition]:
     """Transform a user function into a Condition model"""
     model_params = dict()
+    model_params["is_udc"] = (bool, True)
     params = inspect.signature(user_func).parameters
     for p in params.values():
         if issubclass(p.annotation, dataframe_type):
@@ -55,10 +56,11 @@ class UserDefinedCondition:
         def user_defined_condition(cond: Condition):
             if owner.__name__ in ["Pandas_Engine", "BigqueryEngine"]:
                 return self.func(
-                    instance.dataset, **cond.model_dump(exclude={"is_aggregate"})
+                    instance.dataset,
+                    **cond.model_dump(exclude={"is_aggregate", "is_udc"}),
                 )
             else:
-                return self.func(**cond.model_dump(exclude={"is_aggregate"}))
+                return self.func(**cond.model_dump(exclude={"is_aggregate", "is_udc"}))
 
         return user_defined_condition
 


### PR DESCRIPTION
- Users can now choose any name for their column name parameter in their UDC (it had to be `col_name` before fix)